### PR TITLE
Fixed nimbus vc run.sh mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ geth-teku:
 	@sleep 60
 
 charon:
+	mkdir data
 	./run_charon.sh
 	./promtoken.sh
 
@@ -69,9 +70,11 @@ run-charon-lighthouse:
 	docker compose up node0 node1 node2 vc0-lighthouse vc1-lighthouse vc2-lighthouse prometheus -d
 
 run-charon-nimbus:
+	mkdir -p data/nimbus/vc{0,1,2}
 	docker compose up node0 node1 node2 vc0-nimbus vc1-nimbus vc2-nimbus prometheus -d
 
 run-charon-lodestar:
+	mkdir -p data/lodestar/vc{0,1,2}
 	docker compose up node0 node1 node2 vc0-lodestar vc1-lodestar vc2-lodestar prometheus -d
 
 run-charon-prysm:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -226,6 +226,7 @@ services:
     volumes:
       - .charon/cluster/node0/validator_keys:/home/validator_keys
       - ./data/nimbus/vc0:/home/user/data
+      - ./nimbus/run.sh:/home/user/data/run.sh
 
   vc1-nimbus:
     build: nimbus
@@ -238,6 +239,7 @@ services:
     volumes:
       - .charon/cluster/node1/validator_keys:/home/validator_keys
       - ./data/nimbus/vc1:/home/user/data
+      - ./nimbus/run.sh:/home/user/data/run.sh
 
   vc2-nimbus:
     build: nimbus
@@ -250,6 +252,7 @@ services:
     volumes:
       - .charon/cluster/node2/validator_keys:/home/validator_keys
       - ./data/nimbus/vc2:/home/user/data
+      - ./nimbus/run.sh:/home/user/data/run.sh
 
   vc0-lodestar:
     image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.18.1}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -314,7 +314,7 @@ services:
       BEACON_NODE_ADDRESS: "http://node0:3600"
       # ETH2_NETWORK: ${ETH2_NETWORK:-goerli}
     volumes:
-      - ./prysm:/home/prysm
+      - ./prysm/run.sh:/home/prysm/run.sh
       - .charon/cluster/node0/validator_keys:/home/charon/validator_keys
       - ./testnet/config.yaml:/home/data/config.yaml
 
@@ -328,7 +328,7 @@ services:
       BEACON_NODE_ADDRESS: "http://node1:3600"
       # ETH2_NETWORK: ${ETH2_NETWORK:-goerli}
     volumes:
-      - ./prysm:/home/prysm
+      - ./prysm/run.sh:/home/prysm/run.sh
       - .charon/cluster/node1/validator_keys:/home/charon/validator_keys
       - ./testnet/config.yaml:/home/data/config.yaml
   
@@ -342,7 +342,7 @@ services:
       BEACON_NODE_ADDRESS: "http://node2:3600"
       # ETH2_NETWORK: ${ETH2_NETWORK:-goerli}
     volumes:
-      - ./prysm:/home/prysm
+      - ./prysm/run.sh:/home/prysm/run.sh
       - .charon/cluster/node2/validator_keys:/home/charon/validator_keys
       - ./testnet/config.yaml:/home/data/config.yaml
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,7 +225,7 @@ services:
       NODE: node0
     volumes:
       - .charon/cluster/node0/validator_keys:/home/validator_keys
-      - ./data/nimbus/vc0:/home/user/data
+      - ./data/nimbus/vc0:/home/user/data/node0
       - ./nimbus/run.sh:/home/user/data/run.sh
 
   vc1-nimbus:
@@ -238,7 +238,7 @@ services:
       NODE: node1
     volumes:
       - .charon/cluster/node1/validator_keys:/home/validator_keys
-      - ./data/nimbus/vc1:/home/user/data
+      - ./data/nimbus/vc1:/home/user/data/node1
       - ./nimbus/run.sh:/home/user/data/run.sh
 
   vc2-nimbus:
@@ -251,7 +251,7 @@ services:
       NODE: node2
     volumes:
       - .charon/cluster/node2/validator_keys:/home/validator_keys
-      - ./data/nimbus/vc2:/home/user/data
+      - ./data/nimbus/vc2:/home/user/data/node2
       - ./nimbus/run.sh:/home/user/data/run.sh
 
   vc0-lodestar:


### PR DESCRIPTION
Without it cannot find `run.sh` and therefore fails to start nimbus VC.