### PR TITLE
*: create volumes before starting compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ geth-teku:
 	@sleep 60
 
 charon:
+	mkdir data
 	./run_charon.sh
 	./promtoken.sh
 
@@ -69,9 +70,11 @@ run-charon-lighthouse:
 	docker compose up node0 node1 node2 vc0-lighthouse vc1-lighthouse vc2-lighthouse prometheus -d
 
 run-charon-nimbus:
+	mkdir -p data/nimbus/vc{0,1,2}
 	docker compose up node0 node1 node2 vc0-nimbus vc1-nimbus vc2-nimbus prometheus -d
 
 run-charon-lodestar:
+	mkdir -p data/lodestar/vc{0,1,2}
 	docker compose up node0 node1 node2 vc0-lodestar vc1-lodestar vc2-lodestar prometheus -d
 
 run-charon-prysm:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,7 +225,7 @@ services:
       NODE: node0
     volumes:
       - .charon/cluster/node0/validator_keys:/home/validator_keys
-      - ./data/nimbus/vc0:/home/user/data
+      - ./data/nimbus/vc0:/home/user/data/node0
       - ./nimbus/run.sh:/home/user/data/run.sh
 
   vc1-nimbus:
@@ -238,7 +238,7 @@ services:
       NODE: node1
     volumes:
       - .charon/cluster/node1/validator_keys:/home/validator_keys
-      - ./data/nimbus/vc1:/home/user/data
+      - ./data/nimbus/vc1:/home/user/data/node1
       - ./nimbus/run.sh:/home/user/data/run.sh
 
   vc2-nimbus:
@@ -251,7 +251,7 @@ services:
       NODE: node2
     volumes:
       - .charon/cluster/node2/validator_keys:/home/validator_keys
-      - ./data/nimbus/vc2:/home/user/data
+      - ./data/nimbus/vc2:/home/user/data/node2
       - ./nimbus/run.sh:/home/user/data/run.sh
 
   vc0-lodestar:


### PR DESCRIPTION
On Linux, directories for volumes that don't exist on disk are created as root.

In order to avoid that, create the `data` directory first, and if needed VC directories as well.