### PR TITLE
*: change sed separator to vertical line

### DIFF
--- a/promtoken.sh
+++ b/promtoken.sh
@@ -19,7 +19,7 @@ token=$PROMETHEUS_REMOTE_WRITE_TOKEN
 config=$(cat prometheus/prometheus.yml)
 
 # Replace the credentials value in the config with the token
-updated_config=$(echo "$config" | sed "s/credentials: \"\"/credentials: \"$token\"/")
+updated_config=$(echo "$config" | sed "s|credentials: \"\"|credentials: \"$token\"|")
 
 # Write the updated configuration back to the YAML file
 echo "$updated_config" > prometheus/prometheustmp.yml


### PR DESCRIPTION
Some prometheus tokens have `/` in them, which breaks the `sed` command. `sed` can use `|` as a separator as well. As our prometheus tokens do not have `|` in them, it is suitable to use this character as a separator.