### PR TITLE
*: fix Teku graffiti override, Makefile improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ geth-teku:
 	@sleep 60
 
 charon:
-	mkdir data
+	mkdir -p data
 	./run_charon.sh
 	./promtoken.sh
 

--- a/network_params_geth_teku.yaml
+++ b/network_params_geth_teku.yaml
@@ -18,7 +18,9 @@ participants:
     cl_log_level: ""
     cl_extra_env_vars: {}
     cl_extra_labels: {}
-    cl_extra_params: []
+    cl_extra_params: [
+      "--validators-graffiti-client-append-format=DISABLED",
+    ]
     cl_tolerations: []
     cl_volume_size: 0
     cl_min_cpu: 0


### PR DESCRIPTION
Disable Teku graffiti override in order to publish blocks, also add the `-p` param to `mkdir` to avoid failing if the `data` directory already exists.