### PR TITLE
remove `max-churn`

### DIFF
--- a/network_params_geth_lighthouse.yaml
+++ b/network_params_geth_lighthouse.yaml
@@ -64,7 +64,7 @@ network_params:
     very lucky have athlete"
   preregistered_validator_count: 0
   genesis_delay: 20
-  max_churn: 8
+  # max_churn: 8
   ejection_balance: 16000000000
   eth1_follow_distance: 2048
   min_validator_withdrawability_delay: 256

--- a/network_params_geth_lodestar.yaml
+++ b/network_params_geth_lodestar.yaml
@@ -64,7 +64,7 @@ network_params:
     very lucky have athlete"
   preregistered_validator_count: 0
   genesis_delay: 20
-  max_churn: 8
+  # max_churn: 8
   ejection_balance: 16000000000
   eth1_follow_distance: 2048
   min_validator_withdrawability_delay: 256

--- a/network_params_geth_nimbus.yaml
+++ b/network_params_geth_nimbus.yaml
@@ -64,7 +64,7 @@ network_params:
     very lucky have athlete"
   preregistered_validator_count: 0
   genesis_delay: 20
-  max_churn: 8
+  # max_churn: 8
   ejection_balance: 16000000000
   eth1_follow_distance: 2048
   min_validator_withdrawability_delay: 256

--- a/network_params_geth_prysm.yaml
+++ b/network_params_geth_prysm.yaml
@@ -64,7 +64,7 @@ network_params:
     very lucky have athlete"
   preregistered_validator_count: 0
   genesis_delay: 20
-  max_churn: 8
+  # max_churn: 8
   ejection_balance: 16000000000
   eth1_follow_distance: 2048
   min_validator_withdrawability_delay: 256

--- a/network_params_geth_teku.yaml
+++ b/network_params_geth_teku.yaml
@@ -66,7 +66,7 @@ network_params:
     very lucky have athlete"
   preregistered_validator_count: 0
   genesis_delay: 20
-  max_churn: 8
+  # max_churn: 8
   ejection_balance: 16000000000
   eth1_follow_distance: 2048
   min_validator_withdrawability_delay: 256


### PR DESCRIPTION
`max_churn` has been removed as a parameter from kurtosis. The [newly introduced variable](https://github.com/ethpandaops/ethereum-package/pull/614/files) has the same default value as we've been using up until now.