### PR TITLE
removed grafana additional param

### DIFF
--- a/network_params_geth_lodestar.yaml
+++ b/network_params_geth_lodestar.yaml
@@ -96,7 +96,6 @@ snooper_enabled: false
 ethereum_metrics_exporter_enabled: false
 parallel_keystore_generation: false
 disable_peer_scoring: false
-grafana_additional_dashboards: []
 persistent: false
 mev_type: mock
 mev_params:

--- a/network_params_geth_nimbus.yaml
+++ b/network_params_geth_nimbus.yaml
@@ -96,7 +96,6 @@ snooper_enabled: false
 ethereum_metrics_exporter_enabled: false
 parallel_keystore_generation: false
 disable_peer_scoring: false
-grafana_additional_dashboards: []
 persistent: false
 mev_type: mock
 mev_params:

--- a/network_params_geth_prysm.yaml
+++ b/network_params_geth_prysm.yaml
@@ -96,7 +96,6 @@ snooper_enabled: false
 ethereum_metrics_exporter_enabled: false
 parallel_keystore_generation: false
 disable_peer_scoring: false
-grafana_additional_dashboards: []
 persistent: false
 mev_type: mock
 mev_params:

--- a/network_params_geth_teku.yaml
+++ b/network_params_geth_teku.yaml
@@ -98,7 +98,6 @@ snooper_enabled: false
 ethereum_metrics_exporter_enabled: false
 parallel_keystore_generation: false
 disable_peer_scoring: false
-grafana_additional_dashboards: []
 persistent: false
 mev_type: mock
 mev_params:


### PR DESCRIPTION
Removed grafana params as kurtosis 1.3.1 is complaining on it. 
Once this was removed we can successfully run make geth-lighthouse/nimbus/lodestar/teku/prysm


This was tested in kubernetes, all work well, execpt make geth-prysm only created EL's but does not create CL's. 