### PR TITLE
k8s vc recreation logic

### DIFF
--- a/Makefile_k8s
+++ b/Makefile_k8s
@@ -1,4 +1,4 @@
-.PHONY: run geth-lighthouse geth-nimbus geth-lodestar geth-prysm geth-teku charon run-charon-lighthouse run-charon-nimbus run-charon-lodestar run-charon-prysm run-charon-teku clean
+.PHONY: run geth-lighthouse geth-nimbus geth-lodestar geth-prysm geth-teku charon run-charon-lighthouse run-charon-nimbus run-charon-lodestar run-charon-prysm run-charon-teku run-k8s-pf-lighthouse run-k8s-pf-nimbus run-k8s-pf-lodestar run-k8s-pf-teku clean
 
 # Define the composite step
 geth-lighthouse-charon-lighthouse: geth-lighthouse charon run-charon-lighthouse
@@ -90,6 +90,11 @@ run-k8s-pf-nimbus:
 	kubectl port-forward cl-2-nimbus-geth 24003:4000 -n kt-kurtosis-geth-nimbus > /dev/null 2>&1 &
 	kubectl port-forward cl-3-nimbus-geth 34003:4000 -n kt-kurtosis-geth-nimbus > /dev/null 2>&1 &
 
+recreate-k8s-pods-nimbus:
+	kubectl apply -f vc-1-geth-nimbus.yaml -n kt-kurtosis-geth-nimbus
+	kubectl apply -f vc-2-geth-nimbus.yaml -n kt-kurtosis-geth-nimbus
+	kubectl apply -f vc-3-geth-nimbus.yaml -n kt-kurtosis-geth-nimbus
+
 run-charon-lodestar:
 	mkdir -p data/lodestar/vc{0,1,2}/{caches,keystores,validator-db}
 	docker compose up node0 node1 node2 vc0-lodestar vc1-lodestar vc2-lodestar prometheus -d
@@ -98,6 +103,11 @@ run-k8s-pf-lodestar:
 	kubectl port-forward cl-1-lodestar-geth 14002:4000 -n kt-kurtosis-geth-lodestar > /dev/null 2>&1 &
 	kubectl port-forward cl-2-lodestar-geth 24002:4000 -n kt-kurtosis-geth-lodestar > /dev/null 2>&1 &
 	kubectl port-forward cl-3-lodestar-geth 34002:4000 -n kt-kurtosis-geth-lodestar > /dev/null 2>&1 &
+
+recreate-k8s-pods-lodestar:
+	kubectl apply -f vc-1-geth-lodestar.yaml -n kt-kurtosis-geth-lodestar
+	kubectl apply -f vc-2-geth-lodestar.yaml -n kt-kurtosis-geth-lodestar
+	kubectl apply -f vc-3-geth-lodestar.yaml -n kt-kurtosis-geth-lodestar
 
 run-charon-prysm:
 	docker compose up node0 node1 node2 vc0-prysm vc1-prysm vc2-prysm prometheus -d
@@ -109,6 +119,14 @@ run-k8s-pf-teku:
 	kubectl port-forward cl-1-teku-geth 14000:4000 -n kt-kurtosis-geth-teku > /dev/null 2>&1 &
 	kubectl port-forward cl-2-teku-geth 24000:4000 -n kt-kurtosis-geth-teku > /dev/null 2>&1 &
 	kubectl port-forward cl-3-teku-geth 34000:4000 -n kt-kurtosis-geth-teku > /dev/null 2>&1 &
+
+recreate-k8s-pods-teku:
+	kubectl apply -f vc-1-geth-teku.yaml -n kt-kurtosis-geth-teku
+	kubectl apply -f vc-2-geth-teku.yaml -n kt-kurtosis-geth-teku
+	kubectl apply -f vc-3-geth-teku.yaml -n kt-kurtosis-geth-teku
+	kubectl apply -f vc-1-geth-teku-service.yaml -n kt-kurtosis-geth-teku
+	kubectl apply -f vc-2-geth-teku-service.yaml -n kt-kurtosis-geth-teku
+	kubectl apply -f vc-3-geth-teku-service.yaml -n kt-kurtosis-geth-teku
 
 exit-lighthouse:
 	./lighthouse/exit.sh 0

--- a/Makefile_k8s
+++ b/Makefile_k8s
@@ -1,4 +1,4 @@
-.PHONY: run geth-lighthouse geth-nimbus geth-lodestar geth-prysm geth-teku charon run-charon-lighthouse run-charon-nimbus run-charon-lodestar run-charon-prysm run-charon-teku run-k8s-pf-lighthouse run-k8s-pf-nimbus run-k8s-pf-lodestar run-k8s-pf-teku clean
+.PHONY: run geth-lighthouse geth-nimbus geth-lodestar geth-prysm geth-teku charon run-charon-lighthouse run-charon-nimbus run-charon-lodestar run-charon-prysm run-charon-teku run-k8s-pf-lighthouse run-k8s-pf-nimbus run-k8s-pf-lodestar run-k8s-pf-teku recreate-k8s-pods-lighthouse recreate-k8s-pods-nimbus recreate-k8s-pods-lodestar recreate-k8s-pods-teku clean
 
 # Define the composite step
 geth-lighthouse-charon-lighthouse: geth-lighthouse charon run-charon-lighthouse
@@ -80,6 +80,9 @@ recreate-k8s-pods-lighthouse:
 	kubectl apply -f vc-1-geth-lighthouse.yaml -n kt-kurtosis-geth-lighthouse
 	kubectl apply -f vc-2-geth-lighthouse.yaml -n kt-kurtosis-geth-lighthouse
 	kubectl apply -f vc-3-geth-lighthouse.yaml -n kt-kurtosis-geth-lighthouse
+	kubectl apply -f vc-1-geth-lighthouse-service.yaml -n kt-kurtosis-geth-lighthouse
+    kubectl apply -f vc-2-geth-lighthouse-service.yaml -n kt-kurtosis-geth-lighthouse
+    kubectl apply -f vc-3-geth-lighthouse-service.yaml -n kt-kurtosis-geth-lighthouse
 
 run-charon-nimbus:
 	mkdir -p data/nimbus/vc{0,1,2}
@@ -94,6 +97,9 @@ recreate-k8s-pods-nimbus:
 	kubectl apply -f vc-1-geth-nimbus.yaml -n kt-kurtosis-geth-nimbus
 	kubectl apply -f vc-2-geth-nimbus.yaml -n kt-kurtosis-geth-nimbus
 	kubectl apply -f vc-3-geth-nimbus.yaml -n kt-kurtosis-geth-nimbus
+	kubectl apply -f vc-1-geth-nimbus-service.yaml -n kt-kurtosis-geth-nimbus
+    kubectl apply -f vc-2-geth-nimbus-service.yaml -n kt-kurtosis-geth-nimbus
+    kubectl apply -f vc-3-geth-nimbus-service.yaml -n kt-kurtosis-geth-nimbus
 
 run-charon-lodestar:
 	mkdir -p data/lodestar/vc{0,1,2}/{caches,keystores,validator-db}
@@ -108,6 +114,9 @@ recreate-k8s-pods-lodestar:
 	kubectl apply -f vc-1-geth-lodestar.yaml -n kt-kurtosis-geth-lodestar
 	kubectl apply -f vc-2-geth-lodestar.yaml -n kt-kurtosis-geth-lodestar
 	kubectl apply -f vc-3-geth-lodestar.yaml -n kt-kurtosis-geth-lodestar
+	kubectl apply -f vc-1-geth-lodestar-service.yaml -n kt-kurtosis-geth-lodestar
+    kubectl apply -f vc-2-geth-lodestar-service.yaml -n kt-kurtosis-geth-lodestar
+    kubectl apply -f vc-3-geth-lodestar-service.yaml -n kt-kurtosis-geth-lodestar
 
 run-charon-prysm:
 	docker compose up node0 node1 node2 vc0-prysm vc1-prysm vc2-prysm prometheus -d

--- a/Makefile_k8s
+++ b/Makefile_k8s
@@ -76,6 +76,11 @@ run-k8s-pf-lighthouse:
 	kubectl port-forward cl-2-lighthouse-geth 24001:4000 -n kt-kurtosis-geth-lighthouse > /dev/null 2>&1 &
 	kubectl port-forward cl-3-lighthouse-geth 34001:4000 -n kt-kurtosis-geth-lighthouse > /dev/null 2>&1 &
 
+recreate-k8s-pods-lighthouse:
+	kubectl apply -f vc-1-geth-lighthouse.yaml -n kt-kurtosis-geth-lighthouse
+	kubectl apply -f vc-2-geth-lighthouse.yaml -n kt-kurtosis-geth-lighthouse
+	kubectl apply -f vc-3-geth-lighthouse.yaml -n kt-kurtosis-geth-lighthouse
+
 run-charon-nimbus:
 	mkdir -p data/nimbus/vc{0,1,2}
 	docker compose up node0 node1 node2 vc0-nimbus vc1-nimbus vc2-nimbus prometheus -d

--- a/run_charon_k8s.sh
+++ b/run_charon_k8s.sh
@@ -254,24 +254,20 @@ cp .env ./${CLUSTER_NAME}/.env
     cp -r lodestar ./${CLUSTER_NAME}/lodestar
 cp -r prometheus ./${CLUSTER_NAME}/prometheus
 cp docker-compose-k8.yml ./${CLUSTER_NAME}/docker-compose.yml
-cp "planprint-${CLUSTER_NAME}" ./${CLUSTER_NAME}/
 rm -rf node*
 rm -rf keystore*
 rm -rf charon-keys
 rm .env
 
-# Find first VC and kill it
-#echo Killing first VC that was started by Kurtosis
-#kubectl get pods -n kt-${CLUSTER_NAME} --no-headers | awk '/^vc-/{print $1}' | xargs kubectl delete pod -n kt-${CLUSTER_NAME}
-#kubectl get services -n kt-${CLUSTER_NAME} --no-headers | awk '/^vc-/{print $1}' | xargs kubectl delete service -n kt-${CLUSTER_NAME}
-
-
-# Save the pods configuration to a YAML file
-kubectl get pod vc-1-geth-${CL_NAME} -n kt-${CLUSTER_NAME} -o yaml > ./${CLUSTER_NAME}/vc-1-geth-${CL_NAME}.yaml
-#kubectl get pod vc-2-geth-${CL_NAME} -n kt-${CLUSTER_NAME} -o yaml > ./${CLUSTER_NAME}/vc-2-geth-${CL_NAME}.yaml
-#kubectl get pod vc-3-geth-${CL_NAME} -n kt-${CLUSTER_NAME} -o yaml > ./${CLUSTER_NAME}/vc-3-geth-${CL_NAME}.yaml
-
-# Delete k8s pods
-kubectl delete pod vc-1-geth-${CL_NAME} -n kt-${CLUSTER_NAME}
-#kubectl delete pod vc-2-geth-${CL_NAME} -n kt-${CLUSTER_NAME}
-#kubectl delete pod vc-3-geth-${CL_NAME} -n kt-${CLUSTER_NAME}
+# Save the k8s VC pods configuration to a YAML file
+kubectl get pod vc-1-geth-${CL_NAME} -n kt-${CLUSTER_NAME} -o yaml > ./${CLUSTER_NAME}/vc-1-geth-${CL_NAME}.yaml && echo "Saving k8s VC pod config file: vc-1-geth-${CL_NAME}.yaml"
+kubectl get pod vc-2-geth-${CL_NAME} -n kt-${CLUSTER_NAME} -o yaml > ./${CLUSTER_NAME}/vc-2-geth-${CL_NAME}.yaml && echo "Saving k8s VC pod config file: vc-2-geth-${CL_NAME}.yaml"
+kubectl get pod vc-3-geth-${CL_NAME} -n kt-${CLUSTER_NAME} -o yaml > ./${CLUSTER_NAME}/vc-3-geth-${CL_NAME}.yaml && echo "Saving k8s VC pod config file: vc-3-geth-${CL_NAME}.yaml"
+# Save the k8s VC service configuration to a YAML file
+kubectl get service vc-1-geth-${CL_NAME} -n kt-${CLUSTER_NAME} -o yaml > ./${CLUSTER_NAME}/vc-1-geth-${CL_NAME}-service.yaml && echo "Saving k8s VC service config file: vc-1-geth-${CL_NAME}-service.yaml"
+kubectl get service vc-2-geth-${CL_NAME} -n kt-${CLUSTER_NAME} -o yaml > ./${CLUSTER_NAME}/vc-2-geth-${CL_NAME}-service.yaml && echo "Saving k8s VC service config file: vc-2-geth-${CL_NAME}-service.yaml"
+kubectl get service vc-3-geth-${CL_NAME} -n kt-${CLUSTER_NAME} -o yaml > ./${CLUSTER_NAME}/vc-3-geth-${CL_NAME}-service.yaml && echo "Saving k8s VC service config file: vc-3-geth-${CL_NAME}-service.yaml"
+# Delete all k8s VC pods.
+kubectl get pods -n kt-${CLUSTER_NAME} --no-headers | awk '/^vc-/{print $1}' | xargs -I {} kubectl delete pod {} -n kt-${CLUSTER_NAME}
+# Delete all k8s VC services.
+kubectl get services -n kt-${CLUSTER_NAME} --no-headers | awk '/^vc-/{print $1}' | xargs -I {} kubectl delete service {} -n kt-${CLUSTER_NAME}

--- a/run_charon_k8s.sh
+++ b/run_charon_k8s.sh
@@ -260,8 +260,18 @@ rm -rf keystore*
 rm -rf charon-keys
 rm .env
 
-
 # Find first VC and kill it
 #echo Killing first VC that was started by Kurtosis
 #kubectl get pods -n kt-${CLUSTER_NAME} --no-headers | awk '/^vc-/{print $1}' | xargs kubectl delete pod -n kt-${CLUSTER_NAME}
 #kubectl get services -n kt-${CLUSTER_NAME} --no-headers | awk '/^vc-/{print $1}' | xargs kubectl delete service -n kt-${CLUSTER_NAME}
+
+
+# Save the pods configuration to a YAML file
+kubectl get pod vc-1-geth-${CL_NAME} -n kt-${CLUSTER_NAME} -o yaml > ./${CLUSTER_NAME}/vc-1-geth-${CL_NAME}.yaml
+#kubectl get pod vc-2-geth-${CL_NAME} -n kt-${CLUSTER_NAME} -o yaml > ./${CLUSTER_NAME}/vc-2-geth-${CL_NAME}.yaml
+#kubectl get pod vc-3-geth-${CL_NAME} -n kt-${CLUSTER_NAME} -o yaml > ./${CLUSTER_NAME}/vc-3-geth-${CL_NAME}.yaml
+
+# Delete k8s pods
+kubectl delete pod vc-1-geth-${CL_NAME} -n kt-${CLUSTER_NAME}
+#kubectl delete pod vc-2-geth-${CL_NAME} -n kt-${CLUSTER_NAME}
+#kubectl delete pod vc-3-geth-${CL_NAME} -n kt-${CLUSTER_NAME}


### PR DESCRIPTION
- removed saving planprint to charon cluster folder, since we only need it in root. And we already have that. 
- added command to save k8s VC pods and services to yaml file of charon cluster folder 
- added command to Makefile recreate k8s VC pods and services

![Screenshot 2024-11-04 at 5 15 09 PM](https://github.com/user-attachments/assets/d35da15a-366d-4510-9132-9551f5400160)
![Screenshot 2024-11-04 at 5 33 37 PM](https://github.com/user-attachments/assets/5c7fcca3-e05c-4a3a-bf62-c477de40ef7d)



 