### PR TITLE
Remove old grafana_additional_dashboards parameter

### DIFF
--- a/network_params_geth_lighthouse.yaml
+++ b/network_params_geth_lighthouse.yaml
@@ -96,7 +96,6 @@ snooper_enabled: false
 ethereum_metrics_exporter_enabled: false
 parallel_keystore_generation: false
 disable_peer_scoring: false
-grafana_additional_dashboards: []
 persistent: false
 mev_type: mock
 mev_params:

--- a/network_params_geth_lodestar.yaml
+++ b/network_params_geth_lodestar.yaml
@@ -96,7 +96,6 @@ snooper_enabled: false
 ethereum_metrics_exporter_enabled: false
 parallel_keystore_generation: false
 disable_peer_scoring: false
-grafana_additional_dashboards: []
 persistent: false
 mev_type: mock
 mev_params:

--- a/network_params_geth_nimbus.yaml
+++ b/network_params_geth_nimbus.yaml
@@ -96,7 +96,6 @@ snooper_enabled: false
 ethereum_metrics_exporter_enabled: false
 parallel_keystore_generation: false
 disable_peer_scoring: false
-grafana_additional_dashboards: []
 persistent: false
 mev_type: mock
 mev_params:

--- a/network_params_geth_prysm.yaml
+++ b/network_params_geth_prysm.yaml
@@ -96,7 +96,6 @@ snooper_enabled: false
 ethereum_metrics_exporter_enabled: false
 parallel_keystore_generation: false
 disable_peer_scoring: false
-grafana_additional_dashboards: []
 persistent: false
 mev_type: mock
 mev_params:

--- a/network_params_geth_teku.yaml
+++ b/network_params_geth_teku.yaml
@@ -98,7 +98,6 @@ snooper_enabled: false
 ethereum_metrics_exporter_enabled: false
 parallel_keystore_generation: false
 disable_peer_scoring: false
-grafana_additional_dashboards: []
 persistent: false
 mev_type: mock
 mev_params:


### PR DESCRIPTION
## Summary
Removing old parameter `grafana_additional_dashboards` since it was changed to `grafana_params.additional_dashboards`, ([source](https://github.com/ethpandaops/ethereum-package/pull/773)).