### PR TITLE
Replace goomy with spamoor

### DIFF
--- a/network_params_geth_lighthouse.yaml
+++ b/network_params_geth_lighthouse.yaml
@@ -79,8 +79,8 @@ additional_services:
   - prometheus_grafana
 tx_spammer_params:
   tx_spammer_extra_args: []
-goomy_blob_params:
-  goomy_blob_args: []
+spamoor_blob_params:
+  spamoor_extra_args: []
 assertoor_params:
   image: ""
   run_stability_check: true

--- a/network_params_geth_lodestar.yaml
+++ b/network_params_geth_lodestar.yaml
@@ -79,8 +79,8 @@ additional_services:
   - prometheus_grafana
 tx_spammer_params:
   tx_spammer_extra_args: []
-goomy_blob_params:
-  goomy_blob_args: []
+spamoor_blob_params:
+  spamoor_extra_args: []
 assertoor_params:
   image: ""
   run_stability_check: true

--- a/network_params_geth_nimbus.yaml
+++ b/network_params_geth_nimbus.yaml
@@ -79,8 +79,8 @@ additional_services:
   - prometheus_grafana
 tx_spammer_params:
   tx_spammer_extra_args: []
-goomy_blob_params:
-  goomy_blob_args: []
+spamoor_blob_params:
+  spamoor_extra_args: []
 assertoor_params:
   image: ""
   run_stability_check: true

--- a/network_params_geth_prysm.yaml
+++ b/network_params_geth_prysm.yaml
@@ -79,8 +79,8 @@ additional_services:
   - prometheus_grafana
 tx_spammer_params:
   tx_spammer_extra_args: []
-goomy_blob_params:
-  goomy_blob_args: []
+spamoor_blob_params:
+  spamoor_extra_args: []
 assertoor_params:
   image: ""
   run_stability_check: true

--- a/network_params_geth_teku.yaml
+++ b/network_params_geth_teku.yaml
@@ -81,8 +81,8 @@ additional_services:
   - prometheus_grafana
 tx_spammer_params:
   tx_spammer_extra_args: []
-goomy_blob_params:
-  goomy_blob_args: []
+spamoor_blob_params:
+  spamoor_extra_args: []
 assertoor_params:
   image: ""
   run_stability_check: true


### PR DESCRIPTION
## Summary

Goomy was replaced by spamoor in this [PR](https://github.com/ethpandaops/ethereum-package/pull/860)