### PR TITLE
AWS Runner with on-demand instances

### DIFF
--- a/kurtosis-aws-runner/README.md
+++ b/kurtosis-aws-runner/README.md
@@ -60,6 +60,11 @@ Example prompt:
 
 Proceed to launch 2 EC2 instances? [y/N]:
 ```
+
+Run the launcher with the following command to terminate the instances prior to the life time:
+```
+python kurtosis_aws_runner.py --terminate
+```
 ---
 
 ## Configuration
@@ -93,7 +98,3 @@ To debug a running instance:
    docker logs <container-id>
    ```
 ---
-
-
-./venv/bin/python kurtosis_aws_runner.py --on-demand --monitoring-token 1243
-./venv/bin/python kurtosis_aws_runner.py --terminate

--- a/kurtosis-aws-runner/README.md
+++ b/kurtosis-aws-runner/README.md
@@ -3,10 +3,12 @@
 This Python script automates the launch of a fleet of EC2 spot instances, each running a different test combination of validator, execution and consensus clients with Charon.
 
 The launcher supports:
-- Run the tests for a branch (e.g., `feat/release-test`)
+- Running tests for a specified branch (e.g., `feat/release-test`)
 - Specifying combinations of EL/CL/VC clients to test against Charon
 - Launching each combination on a separate EC2 instance
 - Automatic shutdown of instances after a defined lifetime
+- Optional use of On-Demand EC2 instances
+- Customizable EC2 instance type per launch
 
 ---
 
@@ -43,7 +45,7 @@ Ensure your AWS credentials are set.
 
 Run the launcher with the following command:
 ```
-python kurtosis_aws_runner.py --branch feat/release-combo-test --lifetime 60
+python kurtosis_aws_runner.py --branch feat/release-combo-test --lifetime 60 --monitoring-token <YOUR_TOKEN>
 ```
 This will:
 - Find all EL/CL/VC combinations (e.g., Teku/Lodestar, Lighthouse/Nimbus)
@@ -64,12 +66,17 @@ Proceed to launch 2 EC2 instances? [y/N]:
 
 The following flags are supported:
 ```
---monitoring-token Obol central monitoring token
---branch           Git branch of the kurtosis-charon repo to test (default: main)
---lifetime         Shutdown time in minutes before the EC2 instance is terminated (default: 60)
---env-dir          The path to the env directory to load the combos config (default: ../deployments/env)
---terminate        Terminates the instances (it creates the instances list from the env combos directory)
+--monitoring-token  Obol central monitoring token (required)
+--branch            Git branch of the kurtosis-charon repo to test (default: main)
+--lifetime          Shutdown time in minutes before the EC2 instance is terminated (default: 60)
+--env-dir           The path to the env directory to load the combos config (default: ../deployments/env)
+--terminate         Terminates the instances (uses combos from the env directory to find instances)
+--on-demand         Use On-Demand EC2 instances instead of Spot instances
+--instance-type     EC2 instance type to launch (default: c6a.xlarge)
 ```
+
+**Note**: The default EBS volume size is 50 GB.
+
 ---
 
 ## Debugging
@@ -77,7 +84,12 @@ The following flags are supported:
 To debug a running instance:
 1. Find the instance ID in the AWS console (tagged with the test combo name).
 2. SSH into the instance:
+   ```
    ssh -i ~/.ssh/your-key.pem ubuntu@<public-ip>
-3. Check the Docker containers logs
-
+   ```
+3. Check the Docker container logs:
+   ```
+   docker ps
+   docker logs <container-id>
+   ```
 ---

--- a/kurtosis-aws-runner/README.md
+++ b/kurtosis-aws-runner/README.md
@@ -93,3 +93,7 @@ To debug a running instance:
    docker logs <container-id>
    ```
 ---
+
+
+./venv/bin/python kurtosis_aws_runner.py --on-demand --monitoring-token 1243
+./venv/bin/python kurtosis_aws_runner.py --terminate

--- a/kurtosis-aws-runner/kurtosis_aws_runner.py
+++ b/kurtosis-aws-runner/kurtosis_aws_runner.py
@@ -11,8 +11,8 @@ from tabulate import tabulate
 KEY_NAME = "kurtosis-fleet"
 SECURITY_GROUP_ID = "sg-0e208fd6ad761cafc"
 SUBNET_ID = "subnet-07d83bab8a2b8cd7d"
-INSTANCE_TYPE = "c6a.xlarge"
-VOLUME_SIZE = 100
+DEFAULT_INSTANCE_TYPE = "c6a.xlarge"
+VOLUME_SIZE = 500
 BASE_TAG = "kurtosis-fleet"
 DEFAULT_ENV_DIR = "../deployments/env"
 GIT_REPO = "https://github.com/ObolNetwork/kurtosis-charon.git"
@@ -119,36 +119,33 @@ def instance_exists(tag_value):
         safe_exit(f"Error checking existing instances: {e}")
 
 
-def launch_instance(combo, ami_id, branch, shutdown_minutes, monitoring_token):
+def launch_instance(combo, ami_id, branch, shutdown_minutes, monitoring_token, instance_type, on_demand):
     tag = instance_tag(combo)
     if instance_exists(tag):
         print(f"⚠️  Skipping existing instance: {tag}")
         return None, None
+
+    params = {
+        "ImageId": ami_id,
+        "InstanceType": instance_type,
+        "KeyName": KEY_NAME,
+        "MinCount": 1,
+        "MaxCount": 1,
+        "SubnetId": SUBNET_ID,
+        "SecurityGroupIds": [SECURITY_GROUP_ID],
+        "UserData": generate_user_data(combo, branch, shutdown_minutes, monitoring_token),
+        "BlockDeviceMappings": [{
+            "DeviceName": "/dev/sda1",
+            "Ebs": {"VolumeSize": VOLUME_SIZE, "VolumeType": "gp3", "DeleteOnTermination": True}
+        }],
+        "TagSpecifications": [{"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": tag}]}],
+        "InstanceInitiatedShutdownBehavior": "terminate"
+    }
+    if not on_demand:
+        params["InstanceMarketOptions"] = {"MarketType": "spot"}
+
     try:
-        resp = ec2.run_instances(
-            ImageId=ami_id,
-            InstanceType=INSTANCE_TYPE,
-            KeyName=KEY_NAME,
-            MinCount=1,
-            MaxCount=1,
-            InstanceMarketOptions={"MarketType": "spot"},
-            SubnetId=SUBNET_ID,
-            SecurityGroupIds=[SECURITY_GROUP_ID],
-            UserData=generate_user_data(combo, branch, shutdown_minutes, monitoring_token),
-            BlockDeviceMappings=[{
-                "DeviceName": "/dev/sda1",
-                "Ebs": {
-                    "VolumeSize": VOLUME_SIZE,
-                    "VolumeType": "gp3",
-                    "DeleteOnTermination": True
-                }
-            }],
-            TagSpecifications=[{
-                "ResourceType": "instance",
-                "Tags": [{"Key": "Name", "Value": tag}]
-            }],
-            InstanceInitiatedShutdownBehavior="terminate"
-        )
+        resp = ec2.run_instances(**params)
         instance = resp["Instances"][0]
         return instance["InstanceId"], tag
     except Exception as e:
@@ -212,8 +209,7 @@ def terminate_instances(tag_values):
         return
 
     print("\n📋 Instances to terminate:\n")
-    print(tabulate([[v["name"], v["ip"], v["state"]] for v in instance_map.values()],
-                   headers=["Name", "IP", "State"]))
+    print(tabulate([[v["name"], v["ip"], v["state"]] for v in instance_map.values()], headers=["Name", "IP", "State"]))
 
     confirm = input("Terminate these instances? [y/N]: ").strip().lower()
     if confirm not in ("y", "yes"):
@@ -238,6 +234,8 @@ def main():
     parser.add_argument("--env-dir", default=DEFAULT_ENV_DIR, help="Directory of combos .env files")
     parser.add_argument("--monitoring-token", required=True, help="Monitoring token for Prometheus remote write")
     parser.add_argument("--terminate", action="store_true", help="Terminate matching EC2 instances")
+    parser.add_argument("--on-demand", action="store_true", help="Use On-Demand EC2 instances (default is Spot)")
+    parser.add_argument("--instance-type", default=DEFAULT_INSTANCE_TYPE, help="EC2 instance type (default: c6a.xlarge)")
     args = parser.parse_args()
 
     shutdown_minutes = parse_lifetime_arg(args.lifetime)
@@ -257,12 +255,13 @@ def main():
         return
 
     ami_id = get_latest_ubuntu_ami()
-    print(f"\n🚀 Launching with AMI {ami_id}, branch '{args.branch}', shutdown in {shutdown_minutes}m\n")
+    print(f"\n🚀 Launching with AMI {ami_id}, branch '{args.branch}', shutdown in {shutdown_minutes}m")
+    print(f"📌 Instance type: {args.instance_type}, On-Demand: {args.on_demand}\n")
 
     launched_ids = []
     id_to_tag = {}
     for combo in combos:
-        iid, tag = launch_instance(combo, ami_id, args.branch, shutdown_minutes, args.monitoring_token)
+        iid, tag = launch_instance(combo, ami_id, args.branch, shutdown_minutes, args.monitoring_token, args.instance_type, args.on_demand)
         if iid:
             launched_ids.append(iid)
             id_to_tag[iid] = tag

--- a/kurtosis-aws-runner/kurtosis_aws_runner.py
+++ b/kurtosis-aws-runner/kurtosis_aws_runner.py
@@ -12,7 +12,10 @@ KEY_NAME = "kurtosis-fleet"
 SECURITY_GROUP_ID = "sg-0e208fd6ad761cafc"
 SUBNET_ID = "subnet-07d83bab8a2b8cd7d"
 DEFAULT_INSTANCE_TYPE = "c6a.xlarge"
-VOLUME_SIZE = 500
+VOLUME_SIZE = 50
+VOLUME_TYPE = "gp3"
+VOLUME_IOPS = 6000  # optimized for Charon test runs
+VOLUME_THROUGHPUT = 250  # MB/s
 BASE_TAG = "kurtosis-fleet"
 DEFAULT_ENV_DIR = "../deployments/env"
 GIT_REPO = "https://github.com/ObolNetwork/kurtosis-charon.git"
@@ -136,7 +139,13 @@ def launch_instance(combo, ami_id, branch, shutdown_minutes, monitoring_token, i
         "UserData": generate_user_data(combo, branch, shutdown_minutes, monitoring_token),
         "BlockDeviceMappings": [{
             "DeviceName": "/dev/sda1",
-            "Ebs": {"VolumeSize": VOLUME_SIZE, "VolumeType": "gp3", "DeleteOnTermination": True}
+            "Ebs": {
+                "VolumeSize": VOLUME_SIZE,
+                "VolumeType": VOLUME_TYPE,
+                "Iops": VOLUME_IOPS,
+                "Throughput": VOLUME_THROUGHPUT,
+                "DeleteOnTermination": True
+            }
         }],
         "TagSpecifications": [{"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": tag}]}],
         "InstanceInitiatedShutdownBehavior": "terminate"

--- a/kurtosis-aws-runner/kurtosis_aws_runner.py
+++ b/kurtosis-aws-runner/kurtosis_aws_runner.py
@@ -241,19 +241,23 @@ def main():
     parser.add_argument("--branch", default="main", help="Git branch to clone (default: main)")
     parser.add_argument("--lifetime", default="120", help="Shutdown after time (default: 120 e.g. 90m, 2h)")
     parser.add_argument("--env-dir", default=DEFAULT_ENV_DIR, help="Directory of combos .env files")
-    parser.add_argument("--monitoring-token", required=True, help="Monitoring token for Prometheus remote write")
+    parser.add_argument("--monitoring-token", help="Monitoring token for Prometheus remote write")
     parser.add_argument("--terminate", action="store_true", help="Terminate matching EC2 instances")
     parser.add_argument("--on-demand", action="store_true", help="Use On-Demand EC2 instances (default is Spot)")
     parser.add_argument("--instance-type", default=DEFAULT_INSTANCE_TYPE, help="EC2 instance type (default: c6a.xlarge)")
     args = parser.parse_args()
 
-    shutdown_minutes = parse_lifetime_arg(args.lifetime)
     combos = get_combos(args.env_dir)
     tag_values = [instance_tag(c) for c in combos]
 
     if args.terminate:
         terminate_instances(tag_values)
         return
+
+    if not args.monitoring_token:
+        safe_exit("Missing required --monitoring-token (unless using --terminate)")
+
+    shutdown_minutes = parse_lifetime_arg(args.lifetime)
 
     print(f"🔍 Found {len(combos)} combinations:")
     for c in combos:


### PR DESCRIPTION
- Add the optional `--on-demand` flag to deploy the Kurtosis test fleet with AWS on-demand instances if the spot is not available.