### PR TITLE
Add local Charon relay

### DIFF
--- a/compose.charon.yaml
+++ b/compose.charon.yaml
@@ -13,9 +13,11 @@ x-node-env: &node-env
   CHARON_LOG_LEVEL: debug
   CHARON_LOG_FORMAT: console
   CHARON_P2P_RELAYS: https://0.relay.obol.tech
+  #CHARON_P2P_RELAYS: http://relay:3640    # Connect to local relay
   CHARON_BUILDER_API: true
   CHARON_VALIDATOR_API_ADDRESS: 0.0.0.0:3600
   CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
+  CHARON_P2P_UDP_ADDRESS: 0.0.0.0:3630
   CHARON_MONITORING_ADDRESS: 0.0.0.0:3620
 
 services:
@@ -27,6 +29,7 @@ services:
   node0:
     <<: *node-base
     container_name: node0
+    #depends_on: [ relay ]
     environment:
       <<: *node-env
       CHARON_PRIVATE_KEY_FILE: /opt/charon/.charon/cluster/node0/charon-enr-private-key
@@ -38,6 +41,7 @@ services:
   node1:
     <<: *node-base
     container_name: node1
+    #depends_on: [ relay ]
     environment:
       <<: *node-env
       CHARON_PRIVATE_KEY_FILE: /opt/charon/.charon/cluster/node1/charon-enr-private-key
@@ -49,6 +53,7 @@ services:
   node2:
     <<: *node-base
     container_name: node2
+    #depends_on: [ relay ]
     environment:
       <<: *node-env
       CHARON_PRIVATE_KEY_FILE: /opt/charon/.charon/cluster/node2/charon-enr-private-key
@@ -56,6 +61,31 @@ services:
       CHARON_JAEGER_SERVICE: node2
       CHARON_P2P_EXTERNAL_HOSTNAME: node2
       CHARON_BEACON_NODE_ENDPOINTS: ${BN_2}
+
+  #           _             
+  #          | |            
+  #  _ __ ___| | __ _ _   _ 
+  # | '__/ _ \ |/ _` | | | |
+  # | | |  __/ | (_| | |_| |
+  # |_|  \___|_|\__,_|\__, |
+  #                    __/ |
+  #                   |___/ 
+  #relay:
+  #  image: obolnetwork/charon:${CHARON_VERSION}
+  #  restart: unless-stopped
+  #  networks: [network1]
+  #  volumes:
+  #    - ./.charon:/opt/charon/.charon/
+  #  user: "${DUID:-}:${DGID:-}" # Used by docker-in-docker as it's based on linux
+  #  container_name: relay
+  #  command: relay
+  #  depends_on: []
+  #  environment:
+  #    <<: *node-env
+  #    CHARON_P2P_RELAY_LOGLEVEL: debug
+  #    CHARON_HTTP_ADDRESS: 0.0.0.0:3640
+  #    CHARON_P2P_ADVERTISE_PRIVATE_ADDRESSES: "true"
+  #    CHARON_P2P_EXTERNAL_HOSTNAME: relay
 
   #                        _ _             _
   #  _ __ ___   ___  _ __ (_) |_ ___  _ __(_)_ __   __ _


### PR DESCRIPTION
Adds a `relay` service to start a local Charon relay.
Useful when developing features that require relay changes.