### PR TITLE
fix: pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/run-cluster.yaml
+++ b/.github/workflows/run-cluster.yaml
@@ -20,7 +20,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
             - name: Setup Kurtosis
               run: |


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions `uses:` references to commit SHAs for supply chain security
- Original version tags preserved as inline comments for maintainability
- Mitigates supply chain attacks where a compromised tag could inject malicious code (ref: Trivy incident March 2026)

## Changes
- All `uses: owner/action@tag` → `uses: owner/action@SHA # tag`
- No version changes, only pinning format

## Test plan
- [x] Verify CI workflows run successfully
- [x] Confirm no action versions changed, only pinning format