### PR TITLE
Add post-Kurtosis container configuration overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,36 +155,42 @@ geth-grandine-charon-vouch:
 geth-lighthouse:
 	CL_TYPE=lighthouse ./setup_el_cl.sh
 	kurtosis run --enclave local-eth-testnet github.com/ethpandaops/ethereum-package@6.0.0 --args-file ./network_params.yaml > planprint
+	./post_kurtosis.sh
 	@echo "Waiting for 10 seconds..."
 	@sleep 10
 
 geth-nimbus:
 	CL_TYPE=nimbus ./setup_el_cl.sh
 	kurtosis run --enclave local-eth-testnet github.com/ethpandaops/ethereum-package@6.0.0 --args-file ./network_params.yaml > planprint
+	./post_kurtosis.sh
 	@echo "Waiting for 10 seconds..."
 	@sleep 10
 
 geth-lodestar:
 	CL_TYPE=lodestar ./setup_el_cl.sh
 	kurtosis run --enclave local-eth-testnet github.com/ethpandaops/ethereum-package@6.0.0 --args-file ./network_params.yaml > planprint
+	./post_kurtosis.sh
 	@echo "Waiting for 10 seconds..."
 	@sleep 10
 
 geth-prysm:
 	CL_TYPE=prysm ./setup_el_cl.sh
 	kurtosis run --enclave local-eth-testnet github.com/ethpandaops/ethereum-package@6.0.0 --args-file ./network_params.yaml > planprint
+	./post_kurtosis.sh
 	@echo "Waiting for 60 seconds... don't skip the wait"
 	@sleep 60
 
 geth-teku:
 	CL_TYPE=teku ./setup_el_cl.sh
 	kurtosis run --enclave local-eth-testnet github.com/ethpandaops/ethereum-package@6.0.0 --args-file ./network_params.yaml > planprint
+	./post_kurtosis.sh
 	@echo "Waiting for 60 seconds... don't skip the wait"
 	@sleep 60
 
 geth-grandine:
 	CL_TYPE=grandine ./setup_el_cl.sh
 	kurtosis run --enclave local-eth-testnet github.com/ethpandaops/ethereum-package@6.0.0 --args-file ./network_params.yaml > planprint
+	./post_kurtosis.sh
 	@echo "Waiting for 60 seconds... don't skip the wait"
 	@sleep 60
 

--- a/post_kurtosis.sh
+++ b/post_kurtosis.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Post-Kurtosis overrides and container configuration adjustments.
+# Run after `kurtosis run` completes to apply any custom policies or settings.
+
+set -e
+
+echo "Running post-Kurtosis setup..."
+
+# Override mev-relay-api restart policy to auto-restart on failure
+echo "Setting mev-relay-api restart policy to 'unless-stopped'..."
+docker update --restart=unless-stopped mev-relay-api 2>/dev/null || true
+
+echo "Post-Kurtosis setup complete."


### PR DESCRIPTION
## Summary
- Create `post_kurtosis.sh` to apply container configuration overrides after Kurtosis completes
- Configure `mev-relay-api` to restart automatically on failure (`unless-stopped` policy)
- Script designed to be extensible for future container-level customizations

## Test plan
- Run `make geth-lighthouse-charon-lodestar` or another target
- Verify `docker inspect mev-relay-api` shows `"RestartPolicy": {"Name": "unless-stopped"}`
- Confirm mev-relay-api restarts if it crashes during cluster operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)