### PR TITLE
deployments: match traditional participant CL+VC to the DV participant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Kurtosis-Charon is a test harness for running Ethereum networks with Charon Distributed Validator (DV) clusters. It uses ObolNetwork's fork of ethereum-package (the `obol` branch, tagged `6.1.0-obol.2`) with Kurtosis to spin up full EL+CL+Charon+VC stacks in a single `kurtosis run` command.
+Kurtosis-Charon is a test harness for running Ethereum networks with Charon Distributed Validator (DV) clusters. It uses ObolNetwork's fork of ethereum-package (the `obol` branch, tagged `6.1.0-obol.3`) with Kurtosis to spin up full EL+CL+Charon+VC stacks in a single `kurtosis run` command.
 
 All 36 CL x VC combos (6 CLs: lighthouse, lodestar, nimbus, teku, prysm, grandine; 6 VCs: lighthouse, lodestar, nimbus, teku, prysm, vouch) are defined as self-contained args-files in `deployments/<cl>-<vc>.yaml`.
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ start-local/%:
 	CHARON_VERSION="$(CHARON_VERSION)" \
 		envsubst '$$CHARON_VERSION $$PROMETHEUS_REMOTE_WRITE_TOKEN' \
 		< ./deployments/$*.yaml > /tmp/$*.yaml
-	kurtosis run --enclave $* github.com/ObolNetwork/ethereum-package@6.1.0-obol.2 --args-file /tmp/$*.yaml
+	kurtosis run --enclave $* github.com/ObolNetwork/ethereum-package@6.1.0-obol.3 --args-file /tmp/$*.yaml
 
 stop-local/%:
 	kurtosis enclave rm -f $*

--- a/aws/kurtosis_aws_runner.py
+++ b/aws/kurtosis_aws_runner.py
@@ -16,7 +16,7 @@ VOLUME_THROUGHPUT = 250  # MB/s
 BASE_TAG = "kurtosis-fleet"
 GIT_REPO = "https://github.com/ObolNetwork/kurtosis-charon.git"
 NETWORK_PARAMS_DIR = "deployments"
-ETHEREUM_PACKAGE = "github.com/ObolNetwork/ethereum-package@6.1.0-obol.2"
+ETHEREUM_PACKAGE = "github.com/ObolNetwork/ethereum-package@6.1.0-obol.3"
 KURTOSIS_DEB_URL = "https://github.com/kurtosis-tech/kurtosis-cli-release-artifacts/releases/download/1.20.0/kurtosis-cli_1.20.0_linux_amd64.deb"
 
 # All 36 CL x VC combos. Shares args-files with the local runner (deployments/).

--- a/deployments/grandine-lighthouse.yaml
+++ b/deployments/grandine-lighthouse.yaml
@@ -1,8 +1,8 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: grandine
+    cl_image: sifrai/grandine:2.0.6
     use_separate_vc: true
     vc_type: lighthouse
     vc_image: sigp/lighthouse:v8.2.1

--- a/deployments/grandine-lodestar.yaml
+++ b/deployments/grandine-lodestar.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: grandine
+    cl_image: sifrai/grandine:2.0.6
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: lodestar
+    vc_image: chainsafe/lodestar:v1.46.0
     count: 2
     supernode: true
 

--- a/deployments/grandine-nimbus.yaml
+++ b/deployments/grandine-nimbus.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: grandine
+    cl_image: sifrai/grandine:2.0.6
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: nimbus
+    vc_image: statusim/nimbus-validator-client:multiarch-v26.7.0
     count: 2
     supernode: true
 

--- a/deployments/grandine-prysm.yaml
+++ b/deployments/grandine-prysm.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: grandine
+    cl_image: sifrai/grandine:2.0.6
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: prysm
+    vc_image: gcr.io/prysmaticlabs/prysm/validator:v7.1.8
     count: 2
     supernode: true
 

--- a/deployments/grandine-teku.yaml
+++ b/deployments/grandine-teku.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: grandine
+    cl_image: sifrai/grandine:2.0.6
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: teku
+    vc_image: consensys/teku:26.8.0
     count: 2
     supernode: true
 

--- a/deployments/grandine-vouch.yaml
+++ b/deployments/grandine-vouch.yaml
@@ -1,8 +1,8 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: grandine
+    cl_image: sifrai/grandine:2.0.6
     use_separate_vc: true
     vc_type: lighthouse
     vc_image: sigp/lighthouse:v8.2.1

--- a/deployments/lighthouse-lodestar.yaml
+++ b/deployments/lighthouse-lodestar.yaml
@@ -4,8 +4,8 @@ participants:
     cl_type: lighthouse
     cl_image: sigp/lighthouse:v8.2.1
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: lodestar
+    vc_image: chainsafe/lodestar:v1.46.0
     count: 2
     supernode: true
 

--- a/deployments/lighthouse-nimbus.yaml
+++ b/deployments/lighthouse-nimbus.yaml
@@ -4,8 +4,8 @@ participants:
     cl_type: lighthouse
     cl_image: sigp/lighthouse:v8.2.1
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: nimbus
+    vc_image: statusim/nimbus-validator-client:multiarch-v26.7.0
     count: 2
     supernode: true
 

--- a/deployments/lighthouse-prysm.yaml
+++ b/deployments/lighthouse-prysm.yaml
@@ -4,8 +4,8 @@ participants:
     cl_type: lighthouse
     cl_image: sigp/lighthouse:v8.2.1
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: prysm
+    vc_image: gcr.io/prysmaticlabs/prysm/validator:v7.1.8
     count: 2
     supernode: true
 

--- a/deployments/lighthouse-teku.yaml
+++ b/deployments/lighthouse-teku.yaml
@@ -4,8 +4,8 @@ participants:
     cl_type: lighthouse
     cl_image: sigp/lighthouse:v8.2.1
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: teku
+    vc_image: consensys/teku:26.8.0
     count: 2
     supernode: true
 

--- a/deployments/lodestar-lighthouse.yaml
+++ b/deployments/lodestar-lighthouse.yaml
@@ -1,8 +1,8 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: lodestar
+    cl_image: chainsafe/lodestar:v1.46.0
     use_separate_vc: true
     vc_type: lighthouse
     vc_image: sigp/lighthouse:v8.2.1

--- a/deployments/lodestar-lodestar.yaml
+++ b/deployments/lodestar-lodestar.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: lodestar
+    cl_image: chainsafe/lodestar:v1.46.0
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: lodestar
+    vc_image: chainsafe/lodestar:v1.46.0
     count: 2
     supernode: true
 

--- a/deployments/lodestar-nimbus.yaml
+++ b/deployments/lodestar-nimbus.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: lodestar
+    cl_image: chainsafe/lodestar:v1.46.0
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: nimbus
+    vc_image: statusim/nimbus-validator-client:multiarch-v26.7.0
     count: 2
     supernode: true
 

--- a/deployments/lodestar-prysm.yaml
+++ b/deployments/lodestar-prysm.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: lodestar
+    cl_image: chainsafe/lodestar:v1.46.0
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: prysm
+    vc_image: gcr.io/prysmaticlabs/prysm/validator:v7.1.8
     count: 2
     supernode: true
 

--- a/deployments/lodestar-teku.yaml
+++ b/deployments/lodestar-teku.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: lodestar
+    cl_image: chainsafe/lodestar:v1.46.0
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: teku
+    vc_image: consensys/teku:26.8.0
     count: 2
     supernode: true
 

--- a/deployments/lodestar-vouch.yaml
+++ b/deployments/lodestar-vouch.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: lodestar
+    cl_image: chainsafe/lodestar:v1.46.0
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: lodestar
+    vc_image: chainsafe/lodestar:v1.46.0
     count: 2
     supernode: true
 

--- a/deployments/nimbus-lighthouse.yaml
+++ b/deployments/nimbus-lighthouse.yaml
@@ -1,8 +1,8 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: nimbus
+    cl_image: statusim/nimbus-eth2:multiarch-v26.7.0
     use_separate_vc: true
     vc_type: lighthouse
     vc_image: sigp/lighthouse:v8.2.1

--- a/deployments/nimbus-lodestar.yaml
+++ b/deployments/nimbus-lodestar.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: nimbus
+    cl_image: statusim/nimbus-eth2:multiarch-v26.7.0
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: lodestar
+    vc_image: chainsafe/lodestar:v1.46.0
     count: 2
     supernode: true
 

--- a/deployments/nimbus-nimbus.yaml
+++ b/deployments/nimbus-nimbus.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: nimbus
+    cl_image: statusim/nimbus-eth2:multiarch-v26.7.0
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: nimbus
+    vc_image: statusim/nimbus-validator-client:multiarch-v26.7.0
     count: 2
     supernode: true
 

--- a/deployments/nimbus-prysm.yaml
+++ b/deployments/nimbus-prysm.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: nimbus
+    cl_image: statusim/nimbus-eth2:multiarch-v26.7.0
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: prysm
+    vc_image: gcr.io/prysmaticlabs/prysm/validator:v7.1.8
     count: 2
     supernode: true
 

--- a/deployments/nimbus-teku.yaml
+++ b/deployments/nimbus-teku.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: nimbus
+    cl_image: statusim/nimbus-eth2:multiarch-v26.7.0
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: teku
+    vc_image: consensys/teku:26.8.0
     count: 2
     supernode: true
 

--- a/deployments/nimbus-vouch.yaml
+++ b/deployments/nimbus-vouch.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: nimbus
+    cl_image: statusim/nimbus-eth2:multiarch-v26.7.0
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: nimbus
+    vc_image: statusim/nimbus-validator-client:multiarch-v26.7.0
     count: 2
     supernode: true
 

--- a/deployments/prysm-lighthouse.yaml
+++ b/deployments/prysm-lighthouse.yaml
@@ -1,8 +1,8 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: prysm
+    cl_image: gcr.io/prysmaticlabs/prysm/beacon-chain:v7.1.8
     use_separate_vc: true
     vc_type: lighthouse
     vc_image: sigp/lighthouse:v8.2.1

--- a/deployments/prysm-lodestar.yaml
+++ b/deployments/prysm-lodestar.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: prysm
+    cl_image: gcr.io/prysmaticlabs/prysm/beacon-chain:v7.1.8
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: lodestar
+    vc_image: chainsafe/lodestar:v1.46.0
     count: 2
     supernode: true
 

--- a/deployments/prysm-nimbus.yaml
+++ b/deployments/prysm-nimbus.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: prysm
+    cl_image: gcr.io/prysmaticlabs/prysm/beacon-chain:v7.1.8
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: nimbus
+    vc_image: statusim/nimbus-validator-client:multiarch-v26.7.0
     count: 2
     supernode: true
 

--- a/deployments/prysm-prysm.yaml
+++ b/deployments/prysm-prysm.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: prysm
+    cl_image: gcr.io/prysmaticlabs/prysm/beacon-chain:v7.1.8
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: prysm
+    vc_image: gcr.io/prysmaticlabs/prysm/validator:v7.1.8
     count: 2
     supernode: true
 

--- a/deployments/prysm-teku.yaml
+++ b/deployments/prysm-teku.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: prysm
+    cl_image: gcr.io/prysmaticlabs/prysm/beacon-chain:v7.1.8
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: teku
+    vc_image: consensys/teku:26.8.0
     count: 2
     supernode: true
 

--- a/deployments/prysm-vouch.yaml
+++ b/deployments/prysm-vouch.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: prysm
+    cl_image: gcr.io/prysmaticlabs/prysm/beacon-chain:v7.1.8
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: prysm
+    vc_image: gcr.io/prysmaticlabs/prysm/validator:v7.1.8
     count: 2
     supernode: true
 

--- a/deployments/teku-lighthouse.yaml
+++ b/deployments/teku-lighthouse.yaml
@@ -1,8 +1,8 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: teku
+    cl_image: consensys/teku:26.8.0
     use_separate_vc: true
     vc_type: lighthouse
     vc_image: sigp/lighthouse:v8.2.1

--- a/deployments/teku-lodestar.yaml
+++ b/deployments/teku-lodestar.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: teku
+    cl_image: consensys/teku:26.8.0
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: lodestar
+    vc_image: chainsafe/lodestar:v1.46.0
     count: 2
     supernode: true
 

--- a/deployments/teku-nimbus.yaml
+++ b/deployments/teku-nimbus.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: teku
+    cl_image: consensys/teku:26.8.0
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: nimbus
+    vc_image: statusim/nimbus-validator-client:multiarch-v26.7.0
     count: 2
     supernode: true
 

--- a/deployments/teku-prysm.yaml
+++ b/deployments/teku-prysm.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: teku
+    cl_image: consensys/teku:26.8.0
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: prysm
+    vc_image: gcr.io/prysmaticlabs/prysm/validator:v7.1.8
     count: 2
     supernode: true
 

--- a/deployments/teku-teku.yaml
+++ b/deployments/teku-teku.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: teku
+    cl_image: consensys/teku:26.8.0
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: teku
+    vc_image: consensys/teku:26.8.0
     count: 2
     supernode: true
 

--- a/deployments/teku-vouch.yaml
+++ b/deployments/teku-vouch.yaml
@@ -1,11 +1,11 @@
 participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: teku
+    cl_image: consensys/teku:26.8.0
     use_separate_vc: true
-    vc_type: lighthouse
-    vc_image: sigp/lighthouse:v8.2.1
+    vc_type: teku
+    vc_image: consensys/teku:26.8.0
     count: 2
     supernode: true
 

--- a/local/runner/.env.example
+++ b/local/runner/.env.example
@@ -10,7 +10,7 @@ RUNNER_STATE_PATH=/var/lib/runner/state.json
 # Optional (defaults shown):
 RUNNER_MONITORING_TOKEN=
 # RUNNER_PARAMS_DIR=<repo>/deployments
-# RUNNER_PACKAGE_REF=github.com/ObolNetwork/ethereum-package@6.1.0-obol.2
+# RUNNER_PACKAGE_REF=github.com/ObolNetwork/ethereum-package@6.1.0-obol.3
 # RUNNER_LOG_DIR=<home>/runner-logs   # where failing-run logs are archived
 
 # Slack file upload of failing-run log archives (optional). Needs a Slack app

--- a/local/runner/README.md
+++ b/local/runner/README.md
@@ -203,7 +203,7 @@ the three required variables is unset or empty.
 | `RUNNER_STATE_PATH` | yes | — | Absolute path to the state file (see below); the containing directory must exist and be writable by the service user. |
 | `RUNNER_PARAMS_DIR` | no | `<RUNNER_REPO_PATH>/deployments` | Directory scanned for `*.yaml` param files every loop iteration. |
 | `RUNNER_MONITORING_TOKEN` | no | `""` | Prometheus remote-write auth token (substituted for `$PROMETHEUS_REMOTE_WRITE_TOKEN` in each param file); empty disables remote-write auth. |
-| `RUNNER_PACKAGE_REF` | no | `github.com/ObolNetwork/ethereum-package@6.1.0-obol.2` | Kurtosis package reference to run. |
+| `RUNNER_PACKAGE_REF` | no | `github.com/ObolNetwork/ethereum-package@6.1.0-obol.3` | Kurtosis package reference to run. |
 | `RUNNER_LOG_DIR` | no | `<home>/runner-logs` | Directory where failing-run log archives (`.tar.gz`) are written. |
 | `RUNNER_SLACK_BOT_TOKEN` | no | `""` | Slack bot token (`files:write` scope) for uploading failing-run log archives. Empty = local save only. |
 | `RUNNER_SLACK_CHANNEL_ID` | no | `""` | Slack channel id to upload failing-run log archives into (needs `RUNNER_SLACK_BOT_TOKEN`). |

--- a/local/runner/main.go
+++ b/local/runner/main.go
@@ -197,7 +197,7 @@ func applyFlags(cfg *config, args []string) {
 func loadConfig() (config, error) {
 	cfg := config{
 		charonTag:              "next",
-		packageRef:             "github.com/ObolNetwork/ethereum-package@6.1.0-obol.2",
+		packageRef:             "github.com/ObolNetwork/ethereum-package@6.1.0-obol.3",
 		runMinutes:             90,
 		startupDeadlineMinutes: 25,
 		sampleIntervalS:        15,

--- a/local/runner/main_test.go
+++ b/local/runner/main_test.go
@@ -483,7 +483,7 @@ func TestLoadConfig(t *testing.T) {
 		if cfg.runMinutes != 90 {
 			t.Errorf("runMinutes = %d, want 90", cfg.runMinutes)
 		}
-		if !strings.HasSuffix(cfg.packageRef, "ethereum-package@6.1.0-obol.2") {
+		if !strings.HasSuffix(cfg.packageRef, "ethereum-package@6.1.0-obol.3") {
 			t.Errorf("packageRef = %q", cfg.packageRef)
 		}
 		if cfg.startupDeadlineMinutes != 25 || cfg.sampleIntervalS != 15 {


### PR DESCRIPTION
## What

Every combo ran `2x lighthouse CL + lighthouse VC` as the non-DV background, regardless of which CL was under test. Participant 1 is now the combo's own CL and VC, so each combo runs **3x the same CL** and the traditional stack is a non-DV mirror of the DV one — the only variable between the two participants is Charon itself.

```diff
   - el_type: geth
     el_image: ethereum/client-go:v1.17.5
-    cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.2.1
+    cl_type: lodestar
+    cl_image: chainsafe/lodestar:v1.46.0
     use_separate_vc: true
     vc_type: lighthouse
     vc_image: sigp/lighthouse:v8.2.1
     count: 2
```

34 of 36 files changed; `lighthouse-lighthouse` and `lighthouse-vouch` were already correct.

## Why

The old topology was quietly lighthouse-centric in ways that distorted results:

- background gossip, aggregation and peer-scoring behaviour was always lighthouse's
- the DV node was a lone instance of its client surrounded by two lighthouses
- mock-mev's builder always talked to a lighthouse beacon node, whatever the combo

While debugging a `lodestar-lighthouse` outage we found the DV lodestar node holding **1-2 peers for an entire run** (58% of samples at 1 peer), eventually isolating itself to 0 peers and failing every duty for the rest of the run. Both lighthouse nodes were degraded too (30% and 14% of samples at 1 peer), so it is not purely a lodestar problem — but a homogeneous network is the control needed to separate "the rig cannot peer" from "these two clients cannot peer with each other".

## Unsupported VC fallbacks

Two clients cannot run a standalone VC in the package:

| combo | traditional VC | reason |
|---|---|---|
| `lodestar-vouch`, `nimbus-vouch`, `prysm-vouch`, `teku-vouch`, `lighthouse-vouch` | the combo's own CL | `vouch VC is only supported as a Charon distributed-validator client` |
| `grandine-vouch` | lighthouse | neither vouch nor grandine VC are supported |

## Images

Traditional VCs use stock upstream images. The DVT-patched `kaloyantanev/*` forks stay on the Charon side only, so the traditional participant remains an unpatched control.

| client | CL image | traditional VC image |
|---|---|---|
| grandine | `sifrai/grandine:2.0.6` | — |
| lighthouse | `sigp/lighthouse:v8.2.1` | `sigp/lighthouse:v8.2.1` |
| lodestar | `chainsafe/lodestar:v1.46.0` | `chainsafe/lodestar:v1.46.0` |
| nimbus | `statusim/nimbus-eth2:multiarch-v26.7.0` | `statusim/nimbus-validator-client:multiarch-v26.7.0` |
| prysm | `.../beacon-chain:v7.1.8` | `.../validator:v7.1.8` |
| teku | `consensys/teku:26.8.0` | `consensys/teku:26.8.0` |

## Package bump: 6.1.0-obol.2 -> 6.1.0-obol.3

**Required for this change, not incidental.** `main.star` builds the mock-mev beacon URL from `all_cl_contexts[0].ip_address`, and only the lighthouse/caplin/consensoor launchers populated that field. With a non-lighthouse first participant the URL became `--beacon-node=http://:4000` and the whole run aborted:

```
An error occurred executing instruction (number 82) at src/mev/flashbots/mock_mev/mock_mev_launcher.star[27:36]
  == SERVICE 'mock-mev' LOGS ===
  Error: "Failed to parse beacon URL: ParseError(EmptyHost)"
```

Fixed in ObolNetwork/ethereum-package#3 and released as `6.1.0-obol.3`. Pin bumped in `Makefile`, `aws/kurtosis_aws_runner.py`, `local/runner/main.go` (+ test, README, `.env.example`) and `CLAUDE.md`.

## Testing

- `go build ./...` and `go test ./...` pass in `local/runner`
- the fix was verified end-to-end locally against the real `lodestar-lighthouse.yaml`: before, mock-mev received `http://:4000` and instruction 82 failed; after, it receives `http://172.16.0.13:4000` and the run completes with mock-mev healthy

Note that `kurtosis run --dry-run` does **not** catch this class of failure — it evaluates Starlark but never starts services. Dry-run passed on all 36 files while every one of them would have failed at runtime.