### PR TITLE
runner: fix epoch-0 subtraction, drop log excerpt, bump lighthouse VC image

### DIFF
--- a/deployments/grandine-lighthouse.yaml
+++ b/deployments/grandine-lighthouse.yaml
@@ -20,7 +20,7 @@ participants:
     charon_node_count: 4
     charon_params:
       charon_vc: lighthouse
-      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix
+      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-2
     count: 1
 network_params:
   network: kurtosis

--- a/deployments/lighthouse-lighthouse.yaml
+++ b/deployments/lighthouse-lighthouse.yaml
@@ -20,7 +20,7 @@ participants:
     charon_node_count: 4
     charon_params:
       charon_vc: lighthouse
-      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix
+      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-2
     count: 1
 network_params:
   network: kurtosis

--- a/deployments/lodestar-lighthouse.yaml
+++ b/deployments/lodestar-lighthouse.yaml
@@ -21,7 +21,7 @@ participants:
     charon_params:
       charon_vc: lighthouse
       # Temporary test image: v8.2.1 + DVT is_aggregator subscription fix.
-      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix
+      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-2
     count: 1
 network_params:
   network: kurtosis

--- a/deployments/nimbus-lighthouse.yaml
+++ b/deployments/nimbus-lighthouse.yaml
@@ -20,7 +20,7 @@ participants:
     charon_node_count: 4
     charon_params:
       charon_vc: lighthouse
-      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix
+      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-2
     count: 1
 network_params:
   network: kurtosis

--- a/deployments/prysm-lighthouse.yaml
+++ b/deployments/prysm-lighthouse.yaml
@@ -20,7 +20,7 @@ participants:
     charon_node_count: 4
     charon_params:
       charon_vc: lighthouse
-      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix
+      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-2
     count: 1
 network_params:
   network: kurtosis

--- a/deployments/teku-lighthouse.yaml
+++ b/deployments/teku-lighthouse.yaml
@@ -20,7 +20,7 @@ participants:
     charon_node_count: 4
     charon_params:
       charon_vc: lighthouse
-      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix
+      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-2
     count: 1
 network_params:
   network: kurtosis

--- a/local/runner/main.go
+++ b/local/runner/main.go
@@ -1162,7 +1162,53 @@ const warmupSlots = 64 // exclude epochs 0 and 1 (2 × 32 slots)
 var (
 	dutyFailedRe = regexp.MustCompile(`"duty"\s*:\s*"(\d+)/([^"]+)"`)
 	peerNameRe   = regexp.MustCompile(`"peer_name"\s*:\s*"([^"]+)"`)
+	// logRecordStartRe matches the start of a charon log record: an optional
+	// kurtosis "[service-name] " prefix followed by the HH:MM:SS.mmm timestamp.
+	// A line that does not match is a continuation of the preceding record.
+	logRecordStartRe = regexp.MustCompile(`^(?:\[[^\]]*\]\s*)?\d{2}:\d{2}:\d{2}\.\d+\s`)
 )
+
+// joinLogRecords merges continuation lines back into the record they belong
+// to. Docker splits a container's stdout, so a single charon log record can
+// span several lines. Long structured payloads are the ones that split, and
+// they are exactly the ones we care about here: an attester "Duty failed"
+// carries its per-validator failure array twice (once in the message, once
+// escaped in the "data" field), which routinely pushes the trailing
+// `"duty": "<slot>/<type>"` field onto a line of its own. Scanning raw lines
+// then finds "Duty failed" without a duty field and drops the record.
+//
+// If the input has no recognisable record starts (an unexpected log format),
+// the raw lines are returned so callers behave no worse than before.
+func joinLogRecords(logs string) []string {
+	lines := strings.Split(logs, "\n")
+
+	var (
+		records []string
+		buf     strings.Builder
+		started bool
+	)
+	for _, line := range lines {
+		if logRecordStartRe.MatchString(line) {
+			if started {
+				records = append(records, buf.String())
+			}
+			buf.Reset()
+			started = true
+		} else if !started {
+			continue // preamble before the first record
+		}
+		buf.WriteString(line)
+	}
+	if started {
+		records = append(records, buf.String())
+	}
+
+	if len(records) == 0 {
+		return lines
+	}
+
+	return records
+}
 
 // epoch0Key is a (peer, duty-type) pair used to key per-node epoch-0
 // failure counts.
@@ -1191,12 +1237,12 @@ func countEpoch0Failures(enclave string) map[epoch0Key]float64 {
 	_, dvNodes, _ := selectLogTargets(containers)
 
 	for _, node := range dvNodes {
-		logs := fetchServiceLogs(enclave, node)
-		peerName := extractPeerName(logs)
+		records := joinLogRecords(fetchServiceLogs(enclave, node))
+		peerName := extractPeerName(records)
 		if peerName == "" {
 			continue
 		}
-		for _, line := range strings.Split(logs, "\n") {
+		for _, line := range records {
 			if !strings.Contains(line, "Duty failed") {
 				continue
 			}
@@ -1215,9 +1261,9 @@ func countEpoch0Failures(enclave string) map[epoch0Key]float64 {
 }
 
 // extractPeerName returns the cluster_peer name from a charon node's log
-// output by finding the "Lock file loaded" line which contains peer_name.
-func extractPeerName(logs string) string {
-	for _, line := range strings.Split(logs, "\n") {
+// records by finding the "Lock file loaded" record which contains peer_name.
+func extractPeerName(records []string) string {
+	for _, line := range records {
 		if !strings.Contains(line, "Lock file loaded") {
 			continue
 		}

--- a/local/runner/main.go
+++ b/local/runner/main.go
@@ -696,7 +696,6 @@ type reportData struct {
 	errMsg      string
 
 	logArchivePath string // local path to the captured-logs tarball (failing runs)
-	logExcerpt     string // short excerpt (Charon error lines) for the Slack message
 	charonVersion  string // charon git commit hash captured during the run (matrix column)
 }
 
@@ -807,9 +806,6 @@ func buildBlocks(d reportData) []map[string]any {
 
 	if d.logArchivePath != "" {
 		txt := fmt.Sprintf("*Logs:* `%s`", d.logArchivePath)
-		if d.logExcerpt != "" {
-			txt += "\n```" + d.logExcerpt + "```"
-		}
 		blocks = append(blocks, map[string]any{
 			"type": "section",
 			"text": map[string]any{"type": "mrkdwn", "text": txt},
@@ -1534,13 +1530,12 @@ func fetchServiceLogs(enclave, container string) string {
 }
 
 // captureFailureLogs dumps the targeted logs for a failing run into a gzipped
-// tarball under cfg.logDir and returns its path plus a short excerpt (error
-// lines from a Charon node) for the Slack message. Best-effort: on any problem
+// tarball under cfg.logDir and returns its path. Best-effort: on any problem
 // it returns whatever it managed (possibly ""), never panicking. Containers are
 // scoped to this enclave via kurtosis's enclave-name label so a leftover
 // container from a prior run can never be captured; docker ps -a is kept so a
 // crashed container (e.g. a VC that exited) is still discovered and captured.
-func captureFailureLogs(cfg config, enclave, name string, cycle int) (archivePath, excerpt string) {
+func captureFailureLogs(cfg config, enclave, name string, cycle int) (archivePath string) {
 	defer func() { _ = recover() }()
 
 	out, err := runCommand("docker", "ps", "-a",
@@ -1548,7 +1543,7 @@ func captureFailureLogs(cfg config, enclave, name string, cycle int) (archivePat
 		"--format", "{{.Names}}")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "runner: log capture: docker ps failed: %v\n", err)
-		return "", ""
+		return ""
 	}
 	var containers []string
 	for _, ln := range strings.Split(out, "\n") {
@@ -1566,12 +1561,12 @@ func captureFailureLogs(cfg config, enclave, name string, cycle int) (archivePat
 	targets = append(targets, vcs...)
 	if len(targets) == 0 {
 		fmt.Fprintln(os.Stderr, "runner: log capture: no BN/Charon/VC containers found")
-		return "", ""
+		return ""
 	}
 
 	staging, err := os.MkdirTemp("", "runner-logs-*")
 	if err != nil {
-		return "", ""
+		return ""
 	}
 	defer os.RemoveAll(staging)
 
@@ -1582,50 +1577,16 @@ func captureFailureLogs(cfg config, enclave, name string, cycle int) (archivePat
 
 	if err := os.MkdirAll(cfg.logDir, 0o755); err != nil {
 		fmt.Fprintf(os.Stderr, "runner: log capture: mkdir %s failed: %v\n", cfg.logDir, err)
-		return "", ""
+		return ""
 	}
 	ts := nowFn().UTC().Format("20060102-150405")
 	archivePath = filepath.Join(cfg.logDir, fmt.Sprintf("cycle%d-%s-%s.tar.gz", cycle, name, ts))
 	if err := makeTarGz(staging, archivePath); err != nil {
 		fmt.Fprintf(os.Stderr, "runner: log capture: archive failed: %v\n", err)
-		return "", ""
+		return ""
 	}
 
-	return archivePath, extractExcerpt(staging, dvNodes)
-}
-
-// extractExcerpt reads the first Charon node's captured log and returns up to
-// ~25 recent noteworthy lines (error/warn/fatal/panic/doppelganger), capped in
-// length, for inlining into the Slack message.
-func extractExcerpt(staging string, dvNodes []string) string {
-	if len(dvNodes) == 0 {
-		return ""
-	}
-	data, err := os.ReadFile(filepath.Join(staging, serviceLabel(dvNodes[0])+".log"))
-	if err != nil {
-		return ""
-	}
-	var hits []string
-	for _, ln := range strings.Split(string(data), "\n") {
-		low := strings.ToLower(ln)
-		if strings.Contains(low, "error") || strings.Contains(low, "erro ") ||
-			strings.Contains(low, "warn") || strings.Contains(low, "fatal") ||
-			strings.Contains(low, "panic") || strings.Contains(low, "doppelganger") {
-			hits = append(hits, ln)
-		}
-	}
-	if len(hits) == 0 {
-		return ""
-	}
-	if len(hits) > 25 {
-		hits = hits[len(hits)-25:]
-	}
-	out := strings.Join(hits, "\n")
-	const maxLen = 1500
-	if len(out) > maxLen {
-		out = out[len(out)-maxLen:]
-	}
-	return serviceLabel(dvNodes[0]) + ":\n" + out
+	return archivePath
 }
 
 // makeTarGz writes a gzipped tarball of every regular file directly in srcDir
@@ -1903,7 +1864,7 @@ func runOne(cfg config, paramFile, name string, cycle int) (result reportData) {
 	if data.status != "ok" {
 		// Capture BN/Charon/VC logs while the enclave is still up (teardown is
 		// deferred), for post-mortem of a failing/degraded combo.
-		data.logArchivePath, data.logExcerpt = captureFailureLogs(cfg, enclave, name, cycle)
+		data.logArchivePath = captureFailureLogs(cfg, enclave, name, cycle)
 	}
 	postBestEffort(cfg, data)
 	if data.logArchivePath != "" {

--- a/local/runner/main_test.go
+++ b/local/runner/main_test.go
@@ -1368,7 +1368,7 @@ func TestCaptureFailureLogs(t *testing.T) {
 	}
 
 	logDir := t.TempDir()
-	archive, excerpt := captureFailureLogs(config{logDir: logDir}, "c2-lodestar-nimbus", "lodestar-nimbus", 2)
+	archive := captureFailureLogs(config{logDir: logDir}, "c2-lodestar-nimbus", "lodestar-nimbus", 2)
 	if archive == "" {
 		t.Fatal("archive path empty")
 	}
@@ -1400,9 +1400,6 @@ func TestCaptureFailureLogs(t *testing.T) {
 	}
 	if !strings.Contains(got["vc-3-geth-lodestar-charon-charon-0.log"], "something bad happened") {
 		t.Error("charon-0 log content missing from archive")
-	}
-	if !strings.Contains(excerpt, "something bad happened") {
-		t.Errorf("excerpt missing the error line: %q", excerpt)
 	}
 	if dockerLogsCalled {
 		t.Error("docker logs must not be used when kurtosis service logs succeeds")
@@ -1555,14 +1552,10 @@ func TestBuildBlocksLogsSection(t *testing.T) {
 	d := reportData{
 		name: "x", cycle: 1, status: "failed", window: "-",
 		logArchivePath: "/home/u/runner-logs/cycle1-x-ts.tar.gz",
-		logExcerpt:     "charon-0:\nERRO boom",
 	}
 	dump := dumpBlocks(buildBlocks(d))
 	if !strings.Contains(dump, "cycle1-x-ts.tar.gz") {
 		t.Errorf("logs section missing archive path: %s", dump)
-	}
-	if !strings.Contains(dump, "ERRO boom") {
-		t.Errorf("logs section missing excerpt: %s", dump)
 	}
 	if strings.Contains(dumpBlocks(buildBlocks(reportData{name: "x", status: "ok", window: "-"})), "*Logs:*") {
 		t.Error("logs section should be absent when no archive was captured")

--- a/local/runner/main_test.go
+++ b/local/runner/main_test.go
@@ -1829,3 +1829,102 @@ func TestCountEpoch0FailuresLogParsing(t *testing.T) {
 		t.Errorf("got %d keys, want 3 (slots 64+ excluded)", len(got))
 	}
 }
+
+// TestCountEpoch0FailuresSplitRecords covers charon records that docker split
+// across several lines. An attester "Duty failed" carries its per-validator
+// failure array twice, which pushes the trailing `"duty"` field onto its own
+// line; scanning raw lines finds "Duty failed" with no duty field and silently
+// drops the record, leaving the expected count un-reduced and reporting a
+// warmup failure as a real one.
+func TestCountEpoch0FailuresSplitRecords(t *testing.T) {
+	oldRun := runCommand
+	defer func() { runCommand = oldRun }()
+
+	// Mirrors a real cycle-19 log: the aggregator record fits on one line,
+	// the attester record is split, and the kurtosis "[service] " prefix is
+	// repeated on every physical line.
+	const p = `[vc-3-geth-lodestar-charon-charon-0] `
+	charonLogs := strings.Join([]string{
+		p + `05:29:58.000 INFO app-start Lock file loaded {"peer_name": "alert-word", "peer_index": 0}`,
+		p + `05:44:33.149 WARN tracker Duty failed: fetch aggregator data: 404 {"reason_code": "bug_fetch_error", "duty": "2/aggregator"}`,
+		p + `05:44:33.435 WARN tracker Duty failed: beacon api submit_attestations: POST failed with status 400: {"code":400,"failures":[{"index":0,"message":"PublishError.NoPeersSubscribedToTopic"}]} {"step": "bcast",`,
+		p + `"reason_code": "broadcast_bn_error", "duty": "2/attester"}`,
+		p + `	app/eth2wrap/eth2wrap.go:323 .wrapError`,
+		p + `05:44:45.072 WARN tracker Duty failed: beacon api submit_attestations: POST failed with status 400: {"code":400,"failures":[{"index":0,"message":"PublishError.NoPeersSubscribedToTopic"}]} {"step": "bcast",`,
+		p + `"reason_code": "broadcast_bn_error", "duty": "3/attester"}`,
+		// A split record beyond the warmup window must still be excluded.
+		p + `06:10:00.000 WARN tracker Duty failed: beacon api submit_attestations: POST failed with status 400: {"step": "bcast",`,
+		p + `"reason_code": "broadcast_bn_error", "duty": "200/attester"}`,
+	}, "\n")
+
+	runCommand = func(name string, args ...string) (string, error) {
+		if name == "docker" && len(args) > 0 && args[0] == "ps" {
+			return "vc-3-geth-lodestar-charon-charon-0--abc123\n", nil
+		}
+		if name == "kurtosis" && len(args) > 0 && args[0] == "service" {
+			return charonLogs, nil
+		}
+		return "", nil
+	}
+
+	got := countEpoch0Failures("test-enclave")
+	if v := got[epoch0Key{peer: "alert-word", duty: "attester"}]; v != 2 {
+		t.Errorf("attester = %v, want 2 (split records at slots 2 and 3)", v)
+	}
+	if v := got[epoch0Key{peer: "alert-word", duty: "aggregator"}]; v != 1 {
+		t.Errorf("aggregator = %v, want 1 (slot 2)", v)
+	}
+	if len(got) != 2 {
+		t.Errorf("got %d keys, want 2 (slot 200 excluded)", len(got))
+	}
+}
+
+func TestJoinLogRecords(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "continuation lines are merged",
+			in: "12:00:00.000 INFO a start\n" +
+				"12:00:01.000 WARN b head {\"x\":\n" +
+				"1}\n" +
+				"12:00:02.000 INFO c done",
+			want: []string{
+				`12:00:00.000 INFO a start`,
+				`12:00:01.000 WARN b head {"x":1}`,
+				`12:00:02.000 INFO c done`,
+			},
+		},
+		{
+			name: "kurtosis service prefix is recognised",
+			in:   "[svc-0] 12:00:00.000 INFO a head\n[svc-0] tail\n",
+			want: []string{`[svc-0] 12:00:00.000 INFO a head[svc-0] tail`},
+		},
+		{
+			name: "preamble before the first record is dropped",
+			in:   "garbage banner\n12:00:00.000 INFO a x",
+			want: []string{`12:00:00.000 INFO a x`},
+		},
+		{
+			name: "unrecognised format falls back to raw lines",
+			in:   "no timestamps here\nsecond line",
+			want: []string{"no timestamps here", "second line"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := joinLogRecords(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d records %q, want %d %q", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("record %d = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
`countEpoch0Failures` required `"Duty failed"` and the `"duty"` field on the same log line, but docker splits long records — and attester failures are the long ones. Those records were dropped, so warm-up failures were reported as real ones for some duty types and not others.

The Slack log excerpt matched any line containing `warn`, selecting a high-volume message that embeds peer signature payloads, then truncated mid-line. Removed.

The lighthouse Charon VC pin was stale: `dvt-agg-fix` still fails attestation aggregation in the first three slots of every epoch. The six `*-lighthouse` combos now pin `dvt-agg-fix-2`.