### PR TITLE
deployments: bump lighthouse Charon VC to dvt-agg-fix-3

### DIFF
--- a/deployments/grandine-lighthouse.yaml
+++ b/deployments/grandine-lighthouse.yaml
@@ -20,7 +20,7 @@ participants:
     charon_node_count: 4
     charon_params:
       charon_vc: lighthouse
-      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-2
+      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-3
     count: 1
 network_params:
   network: kurtosis

--- a/deployments/lighthouse-lighthouse.yaml
+++ b/deployments/lighthouse-lighthouse.yaml
@@ -20,7 +20,7 @@ participants:
     charon_node_count: 4
     charon_params:
       charon_vc: lighthouse
-      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-2
+      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-3
     count: 1
 network_params:
   network: kurtosis

--- a/deployments/lodestar-lighthouse.yaml
+++ b/deployments/lodestar-lighthouse.yaml
@@ -21,7 +21,7 @@ participants:
     charon_params:
       charon_vc: lighthouse
       # Temporary test image: v8.2.1 + DVT is_aggregator subscription fix.
-      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-2
+      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-3
     count: 1
 network_params:
   network: kurtosis

--- a/deployments/nimbus-lighthouse.yaml
+++ b/deployments/nimbus-lighthouse.yaml
@@ -20,7 +20,7 @@ participants:
     charon_node_count: 4
     charon_params:
       charon_vc: lighthouse
-      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-2
+      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-3
     count: 1
 network_params:
   network: kurtosis

--- a/deployments/prysm-lighthouse.yaml
+++ b/deployments/prysm-lighthouse.yaml
@@ -20,7 +20,7 @@ participants:
     charon_node_count: 4
     charon_params:
       charon_vc: lighthouse
-      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-2
+      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-3
     count: 1
 network_params:
   network: kurtosis

--- a/deployments/teku-lighthouse.yaml
+++ b/deployments/teku-lighthouse.yaml
@@ -20,7 +20,7 @@ participants:
     charon_node_count: 4
     charon_params:
       charon_vc: lighthouse
-      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-2
+      charon_vc_image: kaloyantanev/lighthouse:dvt-agg-fix-3
     count: 1
 network_params:
   network: kurtosis


### PR DESCRIPTION
`dvt-agg-fix-2` made only one selections request per epoch, and it made it an epoch early. The optional lookahead call drained the duty batch, which ended the polling loop before the mandatory call at the start of the duties' own epoch could run — and that mandatory call is the only one the middleware guarantees it can satisfy. Coverage therefore rested entirely on an optional request that may go unanswered depending on which validator clients are in the cluster.

`dvt-agg-fix-3` keeps the batch queued so the mandatory call still runs. Two independent requests now go out at the start of each epoch: the mandatory one covering the current epoch, and the optional one covering the next. Verified on a live `lodestar-lighthouse` run — at the epoch-2 boundary Charon received the mandatory request for slots 64-95 and the optional one for slots 96-127, where previously only a single request for the next epoch arrived.

Fix is in KaloyanTanev/lighthouse#1.